### PR TITLE
Update test_integration.py

### DIFF
--- a/core/test_integration.py
+++ b/core/test_integration.py
@@ -47,7 +47,6 @@ class IntegrationTests(object):
         super().tearDownClass()
 
         if getattr(cls, 'browser') is not None:
-            time.sleep(2)  # Keep the browser open for 2 seconds
             cls.browser.quit()
 
     def find_url(self, *args, **kwargs):

--- a/core/test_integration.py
+++ b/core/test_integration.py
@@ -227,7 +227,7 @@ class ChromeIntegrationTests(IntegrationTests, StaticLiveServerTestCase):
     def setUpClass(cls):
         options = ChromeOptions()
 
-        options.page_load_strategy = 'normal'
+        options.page_load_strategy = 'eager'
 
         if settings.TEST_INTEGRATION_HEADLESS:
             options.add_argument('--headless=new')


### PR DESCRIPTION
remove implicit wait
I made this change when testing for a new feature I added, Invitation Expiration. I had left this for debugging early on when I was running the browser in head