### PR TITLE
Handle display of invites for the sender

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -292,6 +292,11 @@ class Invitation(models.Model):
     def get_absolute_url(self):
         return reverse('invite_detail', args=[str(self.pk)])
 
+    def is_accepted(self):
+        return self.owner.connections.filter(
+            other_user__in=self.circles.values_list('owner', flat=True)
+        ).exists()
+
 class Intro(models.Model):
     '''
     An Intro is created by `owner` and sent to ONE user, `receiver`.

--- a/core/templates/core/invitation_detail.html
+++ b/core/templates/core/invitation_detail.html
@@ -23,6 +23,15 @@
   {% endfor %}
 
   The following message will be displayed to other users who visit this page:
+
+  <p>
+    <strong>Acceptance Status:</strong>
+    {% if object.is_accepted %}
+      Accepted
+    {% else %}
+      Not Accepted
+    {% endif %}
+  </p>
 {% endif %}
 
 <p>

--- a/core/test_views.py
+++ b/core/test_views.py
@@ -17,3 +17,26 @@ class InvitationViewTests(TestCase):
         self.client0.login(username='test0', password='password0')
         self.client1 = Client()
         self.client1.login(username='test1', password='password1')
+
+    def test_invitation_acceptance_status_for_sender(self):
+        invitation = self.user0.create_invitation(
+            circles=self.user0.circles.all(),
+        )
+        response = self.client0.get(reverse('invite_detail', args=[invitation.pk]))
+        self.assertContains(response, 'Acceptance Status:')
+        self.assertContains(response, 'Not Accepted')
+
+        self.user1.accept_invitation(
+            invitation,
+            circles=self.user1.circles.all(),
+        )
+        response = self.client0.get(reverse('invite_detail', args=[invitation.pk]))
+        self.assertContains(response, 'Acceptance Status:')
+        self.assertContains(response, 'Accepted')
+
+    def test_invitation_acceptance_status_for_receiver(self):
+        invitation = self.user0.create_invitation(
+            circles=self.user0.circles.all(),
+        )
+        response = self.client1.get(reverse('invite_detail', args=[invitation.pk]))
+        self.assertNotContains(response, 'Acceptance Status:')

--- a/core/views.py
+++ b/core/views.py
@@ -413,6 +413,7 @@ class InvitationDetailView(DetailView):
                 data['qr'] = mark_safe(
                     qr_buffer.getvalue().decode('utf-8'),
                 )
+                data['acceptance_status'] = self.object.is_accepted()
             else:
                 data['form'] = forms.InvitationAcceptForm(
                     circles=self.request.user.circles.all(),
@@ -525,7 +526,7 @@ class PostCreateView(CreateView):
         return result
 
     def form_valid(self, form):
-        post = form.save(commit=False)
+        post = form.save(commit(False)
         post.owner = self.request.user
         post.save()
         circle_ids = set(


### PR DESCRIPTION
Fixes #126

Add acceptance status display for invites in invitation detail view.

* Modify `core/templates/core/invitation_detail.html` to include acceptance status for the sender.
* Add `is_accepted` method to `Invitation` model in `core/models.py`.
* Update `InvitationDetailView` in `core/views.py` to include acceptance status in the context data.
* Add tests in `core/test_views.py` to check if the acceptance status is displayed correctly for the sender and not displayed for the receiver.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kerkeslager/friendzone/issues/126?shareId=24f8a498-67dc-4d89-92d7-10e7391dfe27).