### PR TITLE
Fix hover effect for links

### DIFF
--- a/core/templates/core/style.css
+++ b/core/templates/core/style.css
@@ -731,3 +731,16 @@ nav.dropdown:has(> label > .open-state:checked) {
     z-index: 0;
   }
 }
+
+/* P07d9 */
+/* Pf2ad */
+a:link,
+a:visited {
+  transition: transform 0.2s ease-in-out;
+}
+
+a:link:hover,
+a:visited:hover {
+  transform: scale(1.1);
+  z-index: 1;
+}


### PR DESCRIPTION
Fixes #80

Add hover effect for links to expand on hover.

* Add CSS rules to `core/templates/core/style.css` to apply a transition effect on hover for links.
* Use the same hover effect as for other links, scaling the link to 1.1 times its original size and increasing the z-index.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kerkeslager/friendzone/pull/153?shareId=a73b2622-180e-4d3a-83da-49c0ccaa2f1e).